### PR TITLE
feat: Add direction_pattern_id_match validation (ISO-486)

### DIFF
--- a/rules.ts
+++ b/rules.ts
@@ -94,6 +94,7 @@ type GtfsRules = {
         wheelchair_accessible: RuleConfig;
         bikes_allowed: RuleConfig;
         stop_sequence: RuleConfig;
+        direction_pattern_id_match: RuleConfig;
     }
     stop_times: {
         _file: Severity;
@@ -532,6 +533,9 @@ const rules: GtfsRules = {
             severity: "error",
         },
         stop_sequence: {
+            severity: "error",
+        },
+        direction_pattern_id_match: {
             severity: "error",
         }
     },

--- a/validator/i18n/en.json
+++ b/validator/i18n/en.json
@@ -644,5 +644,10 @@
         "recommended": "Field \"origin_id\" is recommended",
         "invalid": "Field \"origin_id\" must be a valid ID from stops.txt",
         "not_allowed": "Field \"origin_id\" \"%s\" is not allowed"
+    },
+    "direction_pattern_id_match": {
+        "invalid_pattern_id": "Field \"pattern_id\" must be a valid ID in the format \"XXXX_[0|1]_1\", received: %s",
+        "invalid_direction_id": "Field \"direction_id\" must be an integer between 0 and 1, received: %s",
+        "not_matching": "Field \"direction_id\" \"%s\" does not match the pattern_id \"%s\""
     }
 }

--- a/validator/i18n/pt.json
+++ b/validator/i18n/pt.json
@@ -645,5 +645,10 @@
         "recommended": "O campo \"origin_id\" é recomendado",
         "invalid": "O campo \"origin_id\" deve ser um ID válido de stops.txt",
         "not_allowed": "O campo \"origin_id\" \"%s\" não é permitido"
+    },
+    "direction_pattern_id_match": {
+        "invalid_pattern_id": "O campo \"pattern_id\" deve ser um ID válido no formato \"XXXX_[0|1]_1\", recebido: %s",
+        "invalid_direction_id": "O campo \"direction_id\" deve ser um número inteiro entre 0 e 1, recebido: %s",
+        "not_matching": "O campo \"direction_id\" \"%s\" não corresponde do pattern_id \"%s\""
     }
 }

--- a/validator/validations/trips/main.go
+++ b/validator/validations/trips/main.go
@@ -5,8 +5,8 @@ import (
 	"main/config"
 	"main/lib"
 	"main/types"
-	validations "main/validations/trips/validations"
 	registry "main/validations"
+	validations "main/validations/trips/validations"
 	"slices"
 )
 
@@ -96,6 +96,9 @@ func RunValidations(gtfs types.Gtfs, rules *types.GtfsRules) {
 
 			tripsGroupedByPattern[*trip.PatternId] = group
 		}
+
+		// Validate direction_id matches pattern_id
+		validations.DirectionPatternIdMatchValidation(&trip, i, &gtfs, tripRules)
 
 		return nil
 	})

--- a/validator/validations/trips/tests/direction_pattern_id_match_validation_test.go
+++ b/validator/validations/trips/tests/direction_pattern_id_match_validation_test.go
@@ -1,0 +1,284 @@
+package trips
+
+import (
+	"main/lib"
+	"main/services"
+	"main/types"
+	validations "main/validations/trips/validations"
+	"testing"
+)
+
+func TestDirectionPatternIdMatchValidation_ValidMatching(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_0_1"
+	directionId := 0
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 1, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Valid matching pattern_id and direction_id should not error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_ValidMatchingDirection1(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_1_2"
+	directionId := 1
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 2, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Valid matching pattern_id with direction_id 1 should not error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_InvalidPatternIdTooFewParts(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_0"
+	directionId := 0
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 3, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Pattern ID with too few parts should error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_InvalidPatternIdTooManyParts(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_0_1_2"
+	directionId := 0
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 4, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Pattern ID with too many parts should error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_InvalidDirectionIdOutOfRange(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_2_1"
+	directionId := 2
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 5, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Pattern ID with direction_id out of range (2) should error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_InvalidDirectionIdNegative(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_-1_1"
+	directionId := -1
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 6, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Pattern ID with negative direction_id should error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_InvalidDirectionIdNotInteger(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_abc_1"
+	directionId := 0
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 7, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Pattern ID with non-integer direction_id should error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_NotMatchingDirectionId0(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_0_1"
+	directionId := 1
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 8, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Pattern ID with direction_id 0 but trip direction_id 1 should error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_NotMatchingDirectionId1(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_1_2"
+	directionId := 0
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_ERROR}}
+	validations.DirectionPatternIdMatchValidation(trip, 9, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Pattern ID with direction_id 1 but trip direction_id 0 should error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_Warning(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_0_1"
+	directionId := 1
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_WARNING}}
+	validations.DirectionPatternIdMatchValidation(trip, 10, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual:   services.AppMessageService.GetSummary().TotalWarnings,
+		Message:  "Non-matching direction_id should produce warning when severity is WARNING",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_Ignore(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_0_1"
+	directionId := 1
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	rules := &types.TripsRules{DirectionId: types.RuleConfig{Severity: types.SEVERITY_IGNORE}}
+	validations.DirectionPatternIdMatchValidation(trip, 11, gtfs, rules)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors + services.AppMessageService.GetSummary().TotalWarnings,
+		Message:  "Non-matching direction_id should be ignored when severity is IGNORE",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}
+
+func TestDirectionPatternIdMatchValidation_NoRules(t *testing.T) {
+	services.AppMessageService.Clear()
+	patternId := "1001_0_1"
+	directionId := 0
+	trip := &types.Trip{
+		PatternId:   lib.Ptr(patternId),
+		DirectionId: &directionId,
+	}
+	gtfs := &types.Gtfs{}
+	validations.DirectionPatternIdMatchValidation(trip, 12, gtfs, nil)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Valid matching pattern_id and direction_id with nil rules should not error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+	services.AppMessageService.Clear()
+}

--- a/validator/validations/trips/validations/direction_pattern_id_match_validation.go
+++ b/validator/validations/trips/validations/direction_pattern_id_match_validation.go
@@ -33,20 +33,20 @@ func DirectionPatternIdMatchValidation(trip *types.Trip, row int, gtfs *types.Gt
 	// Must have three parts: routeId, directionId, variant
 	patternIdParts := strings.Split(*trip.PatternId, "_")
 	if len(patternIdParts) != 3 {
-		ctx.AddError(ctx.GetTranslatedMessage("direction_pattern_id_match.invalid_pattern_id"))
+		ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("direction_pattern_id_match.invalid_pattern_id"))
 		return
 	}
 
 	// Parse the directionId part (second part) as integer
 	directionId, err := strconv.Atoi(patternIdParts[1])
 	if err != nil || directionId < 0 || directionId > 1 {
-		ctx.AddError(ctx.GetTranslatedMessage("direction_pattern_id_match.invalid_direction_id"))
+		ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("direction_pattern_id_match.invalid_direction_id"))
 		return
 	}
 
 	// Ensure trip.DirectionId matches parsed directionId from patternId
 	if *trip.DirectionId != directionId {
-		ctx.AddError(ctx.GetTranslatedMessage("direction_pattern_id_match.not_matching"))
+		ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("direction_pattern_id_match.not_matching"))
 		return
 	}
 }

--- a/validator/validations/trips/validations/direction_pattern_id_match_validation.go
+++ b/validator/validations/trips/validations/direction_pattern_id_match_validation.go
@@ -1,0 +1,52 @@
+package trips
+
+import (
+	"main/lib"
+	"main/services"
+	"main/types"
+	"strconv"
+	"strings"
+)
+
+/*
+# Attributes
+  - File: [trips.txt]
+  - Field: direction_id
+  - Presence: Required
+  - Type: ID
+
+# Description
+
+Ensure the direction_id is consistent with the pattern_id (e.g., pattern_id "1001_0_1" should have direction_id = 0).
+*/
+func DirectionPatternIdMatchValidation(trip *types.Trip, row int, gtfs *types.Gtfs, rules *types.TripsRules) {
+	ctx := lib.NewValidationContext("direction_pattern_id_match", "trips.txt", "direction_pattern_id_match", row, services.AppMessageService)
+	if rules != nil && rules.DirectionId.Severity != "" {
+		ctx.WithSeverity(rules.DirectionId.Severity)
+	}
+
+	if ctx.ShouldSkip() {
+		return
+	}
+
+	// Split the pattern_id using underscore
+	// Must have three parts: routeId, directionId, variant
+	patternIdParts := strings.Split(*trip.PatternId, "_")
+	if len(patternIdParts) != 3 {
+		ctx.AddError(ctx.GetTranslatedMessage("direction_pattern_id_match.invalid_pattern_id"))
+		return
+	}
+
+	// Parse the directionId part (second part) as integer
+	directionId, err := strconv.Atoi(patternIdParts[1])
+	if err != nil || directionId < 0 || directionId > 1 {
+		ctx.AddError(ctx.GetTranslatedMessage("direction_pattern_id_match.invalid_direction_id"))
+		return
+	}
+
+	// Ensure trip.DirectionId matches parsed directionId from patternId
+	if *trip.DirectionId != directionId {
+		ctx.AddError(ctx.GetTranslatedMessage("direction_pattern_id_match.not_matching"))
+		return
+	}
+}


### PR DESCRIPTION
## Description

This PR adds a new validation rule to ensure that the `direction_id` field in `trips.txt` is consistent with the direction embedded in the `pattern_id` field.

## Changes

- **New validation**: `direction_pattern_id_match` validation in `trips` module
  - Validates that `pattern_id` follows the expected format: `XXXX_[0|1]_1`
  - Extracts the direction from the `pattern_id` (second part)
  - Ensures `direction_id` matches the direction in `pattern_id`

- **Configuration**: Added `direction_pattern_id_match` rule configuration in `rules.ts` with error severity

- **Internationalization**: Added error messages in English and Portuguese:
  - `invalid_pattern_id`: When pattern_id format is invalid
  - `invalid_direction_id`: When direction_id is not 0 or 1
  - `not_matching`: When direction_id doesn't match pattern_id

## Example

If a trip has:
- `pattern_id` = "1001_0_1"
- `direction_id` = 0 ✓ (valid)

If a trip has:
- `pattern_id` = "1001_0_1"
- `direction_id` = 1 ✗ (invalid - will raise error)

## Related

- ISO-486