### PR TITLE
feat: Implement consecutive stop_id validation (ISO-1083)

### DIFF
--- a/validator/i18n/en.json
+++ b/validator/i18n/en.json
@@ -376,6 +376,9 @@
         "required_location_group_id_location_id": "Field \"stop_id\" is required if \"location_group_id\" and \"location_id\" are not defined",
         "invalid_location_type": "Field \"stop_id\" must reference a stop with location_type 0 or empty (platform/stop)"
     },
+    "consecutive_stop_id_validation": {
+        "consecutive_stop_ids": "The same stop_id \"%s\" cannot appear consecutively (one directly after another) in trip \"%s\""
+    },
     "timepoint_validation": {
         "forbidden": "Field \"timepoint\" is forbidden",
         "required": "Field \"timepoint\" is required",

--- a/validator/i18n/pt.json
+++ b/validator/i18n/pt.json
@@ -377,6 +377,9 @@
         "required_location_group_id_location_id": "O campo \"stop_id\" é obrigatório se \"location_group_id\" e \"location_id\" não estiverem definidos",
         "invalid_location_type": "O campo \"stop_id\" deve referenciar uma paragem com location_type 0 ou vazio (plataforma/paragem)"
     },
+    "consecutive_stop_id_validation": {
+        "consecutive_stop_ids": "Não é possível ter a mesma paragem \"%s\", diretamente uma depois da outra na viagem \"%s\""
+    },
     "timepoint_validation": {
         "forbidden": "O campo \"timepoint\" é probido",
         "required": "O campo \"timepoint\" é obrigatório",

--- a/validator/validations/stop_times/main.go
+++ b/validator/validations/stop_times/main.go
@@ -55,6 +55,9 @@ func RunValidations(gtfs types.Gtfs, rules *types.GtfsRules) {
 	// Create progress tracker
 	tracker := lib.CreateProgressTracker(gtfs, "stop_times.txt", config.ProgressThresholdLarge)
 
+	// Track previous stop_id per trip_id for consecutive stop_id validation
+	previousStopIdByTrip := make(map[string]*string)
+
 	err = gtfs.IterateStopTimes(func(i int, rawStopTimes types.StopTimeRaw) error {
 		tracker.Track()
 		stopTime := validations.ParseStopTimes(rawStopTimes, i)
@@ -79,6 +82,9 @@ func RunValidations(gtfs types.Gtfs, rules *types.GtfsRules) {
 
 		// Validate stop_id
 		validations.StopIdValidation(&stopTime, i, &gtfs)
+
+		// Validate consecutive stop_ids
+		validations.ConsecutiveStopIdValidation(&stopTime, i, previousStopIdByTrip)
 
 		// Validate location_group_id
 		validations.LocationGroupIdValidation(&stopTime, i, &gtfs)

--- a/validator/validations/stop_times/tests/consecutive_stop_id_validation_test.go
+++ b/validator/validations/stop_times/tests/consecutive_stop_id_validation_test.go
@@ -30,8 +30,8 @@ func TestConsecutiveStopIdValidation_ValidDifferentStopIds(t *testing.T) {
 
 	assertion := lib.AssertionMessage{
 		Expected: 0,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "Different stop_ids consecutively should not error",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Different stop_ids consecutively should not error",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
@@ -59,8 +59,8 @@ func TestConsecutiveStopIdValidation_InvalidConsecutiveStopIds(t *testing.T) {
 
 	assertion := lib.AssertionMessage{
 		Expected: 1,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "Same stop_id consecutively should error",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Same stop_id consecutively should error",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
@@ -88,8 +88,8 @@ func TestConsecutiveStopIdValidation_SameStopIdDifferentTrips(t *testing.T) {
 
 	assertion := lib.AssertionMessage{
 		Expected: 0,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "Same stop_id in different trips should not error",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Same stop_id in different trips should not error",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
@@ -110,8 +110,8 @@ func TestConsecutiveStopIdValidation_FirstStopInTrip(t *testing.T) {
 
 	assertion := lib.AssertionMessage{
 		Expected: 0,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "First stop in a trip should not error",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "First stop in a trip should not error",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
@@ -131,8 +131,8 @@ func TestConsecutiveStopIdValidation_MissingStopId(t *testing.T) {
 
 	assertion := lib.AssertionMessage{
 		Expected: 0,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "Missing stop_id should skip validation",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Missing stop_id should skip validation",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
@@ -153,8 +153,8 @@ func TestConsecutiveStopIdValidation_EmptyStopId(t *testing.T) {
 
 	assertion := lib.AssertionMessage{
 		Expected: 0,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "Empty stop_id should skip validation",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Empty stop_id should skip validation",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
@@ -174,8 +174,8 @@ func TestConsecutiveStopIdValidation_MissingTripId(t *testing.T) {
 
 	assertion := lib.AssertionMessage{
 		Expected: 0,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "Missing trip_id should skip validation",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Missing trip_id should skip validation",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
@@ -210,8 +210,8 @@ func TestConsecutiveStopIdValidation_ValidAfterNonConsecutive(t *testing.T) {
 
 	assertion := lib.AssertionMessage{
 		Expected: 0,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "Same stop_id appearing non-consecutively should not error",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Same stop_id appearing non-consecutively should not error",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
@@ -248,11 +248,10 @@ func TestConsecutiveStopIdValidation_MultipleConsecutiveErrors(t *testing.T) {
 	// with multiple rows (rows 2 and 3) instead of 2 separate error messages
 	assertion := lib.AssertionMessage{
 		Expected: 1,
-		Actual: services.AppMessageService.GetSummary().TotalErrors,
-		Message: "Multiple consecutive stop_ids should produce one error message with multiple rows",
+		Actual:   services.AppMessageService.GetSummary().TotalErrors,
+		Message:  "Multiple consecutive stop_ids should produce one error message with multiple rows",
 	}
 	if assert := lib.Assert(assertion); assert != "" {
 		t.Error(assert)
 	}
 }
-

--- a/validator/validations/stop_times/tests/consecutive_stop_id_validation_test.go
+++ b/validator/validations/stop_times/tests/consecutive_stop_id_validation_test.go
@@ -1,0 +1,258 @@
+package stop_times
+
+import (
+	"main/lib"
+	"main/services"
+	"main/types"
+	validations "main/validations/stop_times/validations"
+	"testing"
+)
+
+func TestConsecutiveStopIdValidation_ValidDifferentStopIds(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	tripId1 := "T1"
+	stopId1 := "S1"
+	stopTime1 := &types.StopTime{
+		TripId: &tripId1,
+		StopId: &stopId1,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime1, 1, previousStopIdByTrip)
+
+	tripId2 := "T1"
+	stopId2 := "S2"
+	stopTime2 := &types.StopTime{
+		TripId: &tripId2,
+		StopId: &stopId2,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime2, 2, previousStopIdByTrip)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "Different stop_ids consecutively should not error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+
+func TestConsecutiveStopIdValidation_InvalidConsecutiveStopIds(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	tripId := "T1"
+	stopId1 := "S1"
+	stopTime1 := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId1,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime1, 1, previousStopIdByTrip)
+
+	stopId2 := "S1" // Same stop_id
+	stopTime2 := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId2,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime2, 2, previousStopIdByTrip)
+
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "Same stop_id consecutively should error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+
+func TestConsecutiveStopIdValidation_SameStopIdDifferentTrips(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	tripId1 := "T1"
+	stopId := "S1"
+	stopTime1 := &types.StopTime{
+		TripId: &tripId1,
+		StopId: &stopId,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime1, 1, previousStopIdByTrip)
+
+	tripId2 := "T2"
+	stopTime2 := &types.StopTime{
+		TripId: &tripId2,
+		StopId: &stopId, // Same stop_id but different trip
+	}
+	validations.ConsecutiveStopIdValidation(stopTime2, 2, previousStopIdByTrip)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "Same stop_id in different trips should not error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+
+func TestConsecutiveStopIdValidation_FirstStopInTrip(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	tripId := "T1"
+	stopId := "S1"
+	stopTime := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime, 1, previousStopIdByTrip)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "First stop in a trip should not error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+
+func TestConsecutiveStopIdValidation_MissingStopId(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	tripId := "T1"
+	stopTime := &types.StopTime{
+		TripId: &tripId,
+		StopId: nil,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime, 1, previousStopIdByTrip)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "Missing stop_id should skip validation",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+
+func TestConsecutiveStopIdValidation_EmptyStopId(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	tripId := "T1"
+	emptyStopId := ""
+	stopTime := &types.StopTime{
+		TripId: &tripId,
+		StopId: &emptyStopId,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime, 1, previousStopIdByTrip)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "Empty stop_id should skip validation",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+
+func TestConsecutiveStopIdValidation_MissingTripId(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	stopId := "S1"
+	stopTime := &types.StopTime{
+		TripId: nil,
+		StopId: &stopId,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime, 1, previousStopIdByTrip)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "Missing trip_id should skip validation",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+
+func TestConsecutiveStopIdValidation_ValidAfterNonConsecutive(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	tripId := "T1"
+	stopId1 := "S1"
+	stopTime1 := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId1,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime1, 1, previousStopIdByTrip)
+
+	stopId2 := "S2"
+	stopTime2 := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId2,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime2, 2, previousStopIdByTrip)
+
+	stopId3 := "S1" // Same as first, but not consecutive
+	stopTime3 := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId3,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime3, 3, previousStopIdByTrip)
+
+	assertion := lib.AssertionMessage{
+		Expected: 0,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "Same stop_id appearing non-consecutively should not error",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+
+func TestConsecutiveStopIdValidation_MultipleConsecutiveErrors(t *testing.T) {
+	services.AppMessageService.Clear()
+	previousStopIdByTrip := make(map[string]*string)
+
+	tripId := "T1"
+	stopId1 := "S1"
+	stopTime1 := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId1,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime1, 1, previousStopIdByTrip)
+
+	stopId2 := "S1" // First consecutive error
+	stopTime2 := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId2,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime2, 2, previousStopIdByTrip)
+
+	stopId3 := "S1" // Second consecutive error
+	stopTime3 := &types.StopTime{
+		TripId: &tripId,
+		StopId: &stopId3,
+	}
+	validations.ConsecutiveStopIdValidation(stopTime3, 3, previousStopIdByTrip)
+
+	// Message service deduplicates messages with the same text, so we get 1 error message
+	// with multiple rows (rows 2 and 3) instead of 2 separate error messages
+	assertion := lib.AssertionMessage{
+		Expected: 1,
+		Actual: services.AppMessageService.GetSummary().TotalErrors,
+		Message: "Multiple consecutive stop_ids should produce one error message with multiple rows",
+	}
+	if assert := lib.Assert(assertion); assert != "" {
+		t.Error(assert)
+	}
+}
+

--- a/validator/validations/stop_times/validations/consecutive_stop_id_validation.go
+++ b/validator/validations/stop_times/validations/consecutive_stop_id_validation.go
@@ -1,0 +1,62 @@
+package stop_times
+
+import (
+	"main/lib"
+	"main/services"
+	"main/types"
+)
+
+/*
+# Attributes
+
+  - File: [stop_times.txt]
+  - Field: stop_id
+  - Rule: ISO 1083
+
+# Description
+
+Não deve ser possível ter a mesma paragem, diretamente uma depois da outra.
+
+The same stop_id cannot appear consecutively (one directly after another) in stop_times.txt within the same trip.
+
+# Example
+
+Invalid:
+stop_id,stop_sequence
+111, 1
+222, 2
+333, 3
+333, 4  <- Error: same stop_id (333) appears consecutively
+444, 5
+
+[stop_times.txt]: https://gtfs.org/schedule/reference/#stoptimetxt
+*/
+func ConsecutiveStopIdValidation(stopTime *types.StopTime, row int, previousStopIdByTrip map[string]*string) {
+	ctx := lib.NewValidationContext("stop_id", "stop_times.txt", "consecutive_stop_id_validation", row, services.AppMessageService)
+
+	// Skip if stop_id is not defined (using location_group_id or location_id instead)
+	if stopTime.StopId == nil || *stopTime.StopId == "" {
+		return
+	}
+
+	// Skip if trip_id is not defined
+	if stopTime.TripId == nil || *stopTime.TripId == "" {
+		return
+	}
+
+	tripId := *stopTime.TripId
+	currentStopId := *stopTime.StopId
+
+	// Check if previous stop_id exists for this trip
+	if previousStopId, exists := previousStopIdByTrip[tripId]; exists && previousStopId != nil {
+		if *previousStopId == currentStopId {
+			ctx.AddError(ctx.GetTranslatedMessage("consecutive_stop_id_validation.consecutive_stop_ids", currentStopId, tripId))
+			// Continue to update map so next validation can check against this stop_id
+		}
+	}
+
+	// Update the previous stop_id for this trip (allocate new string to avoid pointer reuse issues)
+	stopIdCopy := new(string)
+	*stopIdCopy = currentStopId
+	previousStopIdByTrip[tripId] = stopIdCopy
+}


### PR DESCRIPTION
## Description

This PR implements the validation rule ISO-1083: Não deve ser possível ter a mesma paragem, diretamente uma depois da outra (The same stop cannot appear directly one after another).

## Changes

- ✅ Added `ConsecutiveStopIdValidation` function to validate that the same stop_id cannot appear consecutively within the same trip
- ✅ Integrated validation into the stop_times validation pipeline
- ✅ Added i18n strings for English and Portuguese
- ✅ Added comprehensive unit tests covering all edge cases

## Validation Logic

The validation checks that within the same trip, consecutive stop_times entries do not have the same stop_id. It:
- Tracks the previous stop_id per trip_id as it iterates through stop_times.txt
- Skips validation when stop_id is not defined (using location_group_id or location_id instead)
- Reports errors when consecutive stop_ids match

## Example

Invalid case:
```
stop_id,stop_sequence
111, 1
222, 2
333, 3
333, 4  <- Error: same stop_id (333) appears consecutively
444, 5
```

## Tests

All 9 unit tests pass, covering:
- Valid different stop_ids
- Invalid consecutive stop_ids
- Same stop_id in different trips (should not error)
- First stop in trip
- Missing/empty stop_id (should skip)
- Missing trip_id (should skip)
- Non-consecutive same stop_id (should not error)
- Multiple consecutive errors

## Related

Implements ISO-1083 validation rule