### PR TITLE
Tml vehicles.txt requirement

### DIFF
--- a/tml-rules.json
+++ b/tml-rules.json
@@ -619,7 +619,7 @@
 		}
 	},
 	"vehicles": {
-		"_file": "ignore",
+		"_file": "error",
 		"agency_id": {
 			"severity": "error"
 		},

--- a/validator/config/gtfs_files.go
+++ b/validator/config/gtfs_files.go
@@ -17,6 +17,7 @@ var GTFSFileToTable = map[string]string{
 	"municipalities.txt":  "municipalities",
 	"periods.txt":         "periods",
 	"shapes.txt":          "shapes",
+	"vehicles.txt":        "vehicles",
 }
 
 // GTFSFiles is the set of valid GTFS filenames that will be processed
@@ -36,6 +37,7 @@ var GTFSFiles = map[string]struct{}{
 	"municipalities.txt":  {},
 	"periods.txt":         {},
 	"shapes.txt":          {},
+	"vehicles.txt":        {},
 }
 
 // GTFSTables is the list of all possible GTFS table names (without .txt extension)
@@ -48,7 +50,7 @@ var GTFSTables = []string{
 	"location_group_stops", "location_groups", "municipalities", "networks",
 	"pathways", "periods", "rider_categories", "route_networks", "routes",
 	"shapes", "stop_areas", "stop_times", "stops", "timeframes", "transfers",
-	"translations", "trips",
+	"translations", "trips", "vehicles",
 }
 
 // FileToTable converts a GTFS file name (with .txt extension) to its table name

--- a/validator/services/rules_parser.go
+++ b/validator/services/rules_parser.go
@@ -220,13 +220,62 @@ func (rp *RulesParser) GetRequiredFiles(rules *types.GtfsRules) []string {
 		return []string{}
 	}
 
-	allFiles := lib.GetAllStructTagValues(types.GtfsRules{}, "json")
 	requiredFiles := make([]string, 0)
-
-	for _, file := range allFiles {
-		if lib.GetFieldByTag(rules, file, "_file") == "error" {
-			requiredFiles = append(requiredFiles, file)
-		}
+	
+	// Check each file rules struct for File field with error severity
+	if rules.Agency.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "agency.txt")
+	}
+	if rules.Stops.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "stops.txt")
+	}
+	if rules.Routes.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "routes.txt")
+	}
+	if rules.Trips.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "trips.txt")
+	}
+	if rules.StopTimes.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "stop_times.txt")
+	}
+	if rules.Calendar.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "calendar.txt")
+	}
+	if rules.CalendarDates.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "calendar_dates.txt")
+	}
+	if rules.Vehicles.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "vehicles.txt")
+	}
+	if rules.FareAttributes.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "fare_attributes.txt")
+	}
+	if rules.FareRules.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "fare_rules.txt")
+	}
+	if rules.Shapes.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "shapes.txt")
+	}
+	if rules.Frequencies.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "frequencies.txt")
+	}
+	if rules.Transfers.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "transfers.txt")
+	}
+	if rules.Pathways.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "pathways.txt")
+	}
+	if rules.Levels.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "levels.txt")
+	}
+	if rules.FeedInfo.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "feed_info.txt")
+	}
+	if rules.Translations.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "translations.txt")
+	}
+	if rules.Attributions.File == types.SEVERITY_ERROR {
+		requiredFiles = append(requiredFiles, "attributions.txt")
 	}
 
 	return requiredFiles
@@ -237,14 +286,63 @@ func (rp *RulesParser) GetForbiddenFiles(rules *types.GtfsRules) []string {
 		return []string{}
 	}
 
-	allFiles := lib.GetAllStructTagValues(types.GtfsRules{}, "json")
-	requiredFiles := make([]string, 0)
-
-	for _, file := range allFiles {
-		if lib.GetFieldByTag(rules, file, "_file") == "forbidden" {
-			requiredFiles = append(requiredFiles, file)
-		}
+	forbiddenFiles := make([]string, 0)
+	
+	// Check each file rules struct for File field with forbidden severity
+	if rules.Agency.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "agency.txt")
+	}
+	if rules.Stops.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "stops.txt")
+	}
+	if rules.Routes.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "routes.txt")
+	}
+	if rules.Trips.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "trips.txt")
+	}
+	if rules.StopTimes.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "stop_times.txt")
+	}
+	if rules.Calendar.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "calendar.txt")
+	}
+	if rules.CalendarDates.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "calendar_dates.txt")
+	}
+	if rules.Vehicles.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "vehicles.txt")
+	}
+	if rules.FareAttributes.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "fare_attributes.txt")
+	}
+	if rules.FareRules.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "fare_rules.txt")
+	}
+	if rules.Shapes.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "shapes.txt")
+	}
+	if rules.Frequencies.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "frequencies.txt")
+	}
+	if rules.Transfers.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "transfers.txt")
+	}
+	if rules.Pathways.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "pathways.txt")
+	}
+	if rules.Levels.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "levels.txt")
+	}
+	if rules.FeedInfo.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "feed_info.txt")
+	}
+	if rules.Translations.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "translations.txt")
+	}
+	if rules.Attributions.File == types.SEVERITY_FORBIDDEN {
+		forbiddenFiles = append(forbiddenFiles, "attributions.txt")
 	}
 
-	return requiredFiles
+	return forbiddenFiles
 }

--- a/validator/validations/files/main_test.go
+++ b/validator/validations/files/main_test.go
@@ -1,9 +1,13 @@
 package file_validation
 
 import (
+	"database/sql"
 	"fmt"
 	"main/types"
+	"os"
 	"testing"
+
+	_ "modernc.org/sqlite"
 )
 
 func TestFileValidation(t *testing.T) {
@@ -210,6 +214,150 @@ func TestFileValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			v := NewFileValidation(&tt.wantSeverity)
 			messages := v.Validate(tt.gtfs, nil)
+
+			if len(messages) != tt.wantMessages {
+				t.Errorf("[%v] FileValidation.Validate() got %v messages, want %v", tt.name, len(messages), tt.wantMessages)
+				for _, msg := range messages {
+					fmt.Println(msg)
+				}
+			}
+
+			for _, msg := range messages {
+				if msg.Severity != tt.wantSeverity {
+					t.Errorf("[%v] FileValidation.Validate() got message with severity %v, want %v", tt.name, msg.Severity, tt.wantSeverity)
+				}
+				if msg.ValidationID != v.ID {
+					t.Errorf("[%v] FileValidation.Validate() got message with validation ID %v, want %v", tt.name, msg.ValidationID, v.ID)
+				}
+			}
+
+			if tt.checkMessages != nil && !tt.checkMessages(messages) {
+				t.Errorf("[%v] FileValidation.Validate() messages did not match expected conditions", tt.name)
+			}
+		})
+	}
+}
+
+// createMockGtfsDB creates a temporary SQLite database with specified tables
+func createMockGtfsDB(t *testing.T, tables []string) (*types.Gtfs, func()) {
+	tmpDB, err := os.CreateTemp("", "test_gtfs_*.db")
+	if err != nil {
+		t.Fatalf("Failed to create temp database: %v", err)
+	}
+	tmpDBPath := tmpDB.Name()
+	tmpDB.Close()
+
+	db, err := sql.Open("sqlite", tmpDBPath)
+	if err != nil {
+		os.Remove(tmpDBPath)
+		t.Fatalf("Failed to open database: %v", err)
+	}
+
+	// Create the specified tables
+	for _, table := range tables {
+		_, err := db.Exec(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (id TEXT)", table))
+		if err != nil {
+			db.Close()
+			os.Remove(tmpDBPath)
+			t.Fatalf("Failed to create table %s: %v", table, err)
+		}
+	}
+
+	gtfs := types.NewGtfsFromSQLite(db, tmpDBPath)
+
+	cleanup := func() {
+		gtfs.Close()
+		os.Remove(tmpDBPath)
+	}
+
+	return gtfs, cleanup
+}
+
+func TestVehiclesRequiredWithRules(t *testing.T) {
+	tests := []struct {
+		name          string
+		tables        []string // Tables to create in the mock database
+		rules         *types.GtfsRules
+		wantMessages  int
+		wantSeverity  types.Severity
+		checkMessages func([]types.Message) bool
+	}{
+		{
+			name:   "vehicles.txt required when rules specify error - missing vehicles",
+			tables: []string{"agency", "routes", "trips", "stop_times", "stops", "calendar"},
+			rules: &types.GtfsRules{
+				Vehicles: types.VehiclesRules{
+					File: types.SEVERITY_ERROR,
+				},
+			},
+			wantMessages: 1,
+			wantSeverity: types.SEVERITY_ERROR,
+			checkMessages: func(messages []types.Message) bool {
+				for _, msg := range messages {
+					if msg.FileName == "vehicles.txt" {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name:   "vehicles.txt required when rules specify error - vehicles present",
+			tables: []string{"agency", "routes", "trips", "stop_times", "stops", "calendar", "vehicles"},
+			rules: &types.GtfsRules{
+				Vehicles: types.VehiclesRules{
+					File: types.SEVERITY_ERROR,
+				},
+			},
+			wantMessages: 0,
+			wantSeverity: types.SEVERITY_ERROR,
+		},
+		{
+			name:   "vehicles.txt not required when rules specify ignore",
+			tables: []string{"agency", "routes", "trips", "stop_times", "stops", "calendar"},
+			rules: &types.GtfsRules{
+				Vehicles: types.VehiclesRules{
+					File: types.SEVERITY_IGNORE,
+				},
+			},
+			wantMessages: 0,
+			wantSeverity: types.SEVERITY_ERROR,
+		},
+		{
+			name:   "vehicles.txt forbidden when rules specify forbidden - vehicles present",
+			tables: []string{"agency", "routes", "trips", "stop_times", "stops", "calendar", "vehicles"},
+			rules: &types.GtfsRules{
+				Vehicles: types.VehiclesRules{
+					File: types.SEVERITY_FORBIDDEN,
+				},
+			},
+			wantMessages: 1,
+			wantSeverity: types.SEVERITY_ERROR,
+			checkMessages: func(messages []types.Message) bool {
+				for _, msg := range messages {
+					if msg.FileName == "vehicles.txt" {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name:         "no error when vehicles.txt not required and not present",
+			tables:       []string{"agency", "routes", "trips", "stop_times", "stops", "calendar"},
+			rules:        nil,
+			wantMessages: 0,
+			wantSeverity: types.SEVERITY_ERROR,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gtfs, cleanup := createMockGtfsDB(t, tt.tables)
+			defer cleanup()
+
+			v := NewFileValidation(&tt.wantSeverity)
+			messages := v.Validate(*gtfs, tt.rules)
 
 			if len(messages) != tt.wantMessages {
 				t.Errorf("[%v] FileValidation.Validate() got %v messages, want %v", tt.name, len(messages), tt.wantMessages)


### PR DESCRIPTION
Make `vehicles.txt` a required file for TML GTFS validation as per ISO-1162.

The `GetRequiredFiles` and `GetForbiddenFiles` functions in `rules_parser.go` were refactored to correctly parse file-level severities from `GtfsRules`, fixing a bug in the previous reflection-based approach and enabling proper enforcement of file requirements.

---
Linear Issue: [ISO-1162](https://linear.app/cmetropolitana/issue/ISO-1162/adicionar-obrigatoriedade-do-ficheiro-vehiclestxt)

<a href="https://cursor.com/background-agent?bcId=bc-51ce1953-7e99-47df-a9fe-e84fcc8a0ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51ce1953-7e99-47df-a9fe-e84fcc8a0ff8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

