### PR TITLE
feat: add trip headsign validation

### DIFF
--- a/validator/i18n/en.json
+++ b/validator/i18n/en.json
@@ -629,6 +629,9 @@
     "direction_id_group_validation": {
         "different_direction_ids_in_pattern": "pattern_id %s has trips with different direction_ids: %s. All trips with the same pattern_id must have the same direction_id"
     },
+    "trip_headsign_group_validation": {
+        "different_headsigns_in_pattern": "pattern_id %s has trips with different trip_headsigns: %s. All trips with the same pattern_id must have the same trip_headsign"
+    },
     "pattern_id_validation": {
         "forbidden": "Field \"pattern_id\" is forbidden",
         "required": "Field \"pattern_id\" is required",

--- a/validator/i18n/pt.json
+++ b/validator/i18n/pt.json
@@ -637,6 +637,9 @@
     "direction_id_group_validation": {
         "different_direction_ids_in_pattern": "pattern_id %s tem viagens com direction_ids diferentes: %s. Todas as viagens com o mesmo pattern_id devem ter o mesmo direction_id"
     },
+    "trip_headsign_group_validation": {
+        "different_headsigns_in_pattern": "pattern_id %s tem viagens com headsigns diferentes: %s. Todas as viagens com o mesmo pattern_id devem ter o mesmo headsign"
+    },
     "pattern_id_validation": {
         "forbidden": "O campo \"pattern_id\" é proibido",
         "required": "O campo \"pattern_id\" é obrigatório",
@@ -650,6 +653,7 @@
         "different_direction_id": "Encontrados direction_id's diferentes para o mesmo pattern_id: %s",
         "different_route_id": "Encontrados route_id's diferentes para o mesmo pattern_id: %s",
         "different_shape_id": "Encontrados shape_id's diferentes para o mesmo pattern_id: %s",
+        "different_headsign": "Encontrados headsigns diferentes para o mesmo pattern_id: %s",
         "different_pattern_id_same_shape": "O shape_id \"%s\" está a ser utilizado por diferentes pattern_ids: \"%s\" e \"%s\"",
         "multiple_stop_sequence_variations": "Para o pattern_id %s, existem viagens com múltiplas variações de sequência de paragens"
     },

--- a/validator/validations/trips/validations/pattern_group_orchestrator.go
+++ b/validator/validations/trips/validations/pattern_group_orchestrator.go
@@ -19,4 +19,5 @@ func ValidatePatternGroups(
 	RouteIdGroupValidation(tripsGroupedByPattern, gtfs)
 	DirectionIdGroupValidation(tripsGroupedByPattern, gtfs)
 	ShapeIdGroupValidation(tripsGroupedByPattern, tripsGroupedByShapeId, gtfs)
+	TripHeadsignGroupValidation(tripsGroupedByPattern, gtfs)
 }

--- a/validator/validations/trips/validations/pattern_id_group_validation.go
+++ b/validator/validations/trips/validations/pattern_id_group_validation.go
@@ -42,6 +42,11 @@ func PatternIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, 
 				ctx.AddError(ctx.GetTranslatedMessage("pattern_id_validation.direction_id_not_found"))
 				continue
 			}
+
+			if trip.TripHeadsign == nil {
+				ctx.AddError(ctx.GetTranslatedMessage("pattern_id_validation.trip_headsign_not_found"))
+				continue
+			}
 		}
 
 		if len(group.Hash) > 1 {

--- a/validator/validations/trips/validations/trip_headsign_group_validation.go
+++ b/validator/validations/trips/validations/trip_headsign_group_validation.go
@@ -1,0 +1,61 @@
+package trips
+
+import (
+	"main/lib"
+	"main/services"
+	"main/types"
+	"sort"
+	"strings"
+)
+
+/*
+# Attributes
+  - File: [trips.txt]
+  - Field: trip_headsign
+  - Presence: Optional (Required for "Transportes Metropolitanos de Lisboa" when pattern_id is set)
+  - Type: Text
+
+# Description
+
+Validates that trip_headsign is unique within each pattern_id.
+All trips with the same pattern_id must have the same trip_headsign (including consistent presence: nil/empty vs non-empty).
+*/
+
+func TripHeadsignGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs) {
+	for patternId, group := range tripsGroupedByPattern {
+		if len(group.Trips) == 0 {
+			panic("trips is empty")
+		}
+
+		headsigns := make(map[string]bool)
+		for _, trip := range group.Trips {
+			key := ""
+			if trip.TripHeadsign != nil {
+				key = *trip.TripHeadsign
+			}
+			headsigns[key] = true
+		}
+
+		if len(headsigns) <= 1 {
+			continue
+		}
+
+		keys := make([]string, 0, len(headsigns))
+		for h := range headsigns {
+			keys = append(keys, h)
+		}
+		sort.Strings(keys)
+		parts := make([]string, len(keys))
+		for i, h := range keys {
+			if h == "" {
+				parts[i] = "[empty]"
+			} else {
+				parts[i] = h
+			}
+		}
+
+		row := group.Trips[0].Row
+		ctx := lib.NewValidationContext("trip_headsign", "trips.txt", "trip_headsign_group_validation", row, services.AppMessageService)
+		ctx.AddError(ctx.GetTranslatedMessage("trip_headsign_group_validation.different_headsigns_in_pattern", patternId, strings.Join(parts, ", ")))
+	}
+}


### PR DESCRIPTION
- Implemented TripHeadsignGroupValidation to ensure unique trip_headsigns within each pattern_id.
- Updated validation logic to check for the presence of trip_headsign and added corresponding error messages in English and Portuguese.
- Enhanced i18n files to include new validation messages for trip headsign discrepancies.