### PR TITLE
feat: enhance trip validation rules with new group checks

### DIFF
--- a/tml-rules.json
+++ b/tml-rules.json
@@ -947,6 +947,21 @@
     },
     "stop_coordinates_by_trip_id": {
       "severity": "error"
+    },
+    "pattern_id_group": {
+      "severity": "error"
+    },
+    "route_id_group": {
+      "severity": "error"
+    },
+    "direction_id_group": {
+      "severity": "error"
+    },
+    "shape_id_group": {
+      "severity": "error"
+    },
+    "trip_headsign_group": {
+      "severity": "error"
     }
   },
   "vehicles": {

--- a/validator/types/gtfs_rules.go
+++ b/validator/types/gtfs_rules.go
@@ -101,6 +101,11 @@ type TripsRules struct {
 	TripIdLimitCharacters   RuleConfig `json:"trip_id_limit_characters"`
 	PatternIdFormat         RuleConfig `json:"pattern_id_format"`
 	StopCoordinatesByTripId RuleConfig `json:"stop_coordinates_by_trip_id"`
+	PatternIdGroup          RuleConfig `json:"pattern_id_group"`
+	RouteIdGroup            RuleConfig `json:"route_id_group"`
+	DirectionIdGroup        RuleConfig `json:"direction_id_group"`
+	ShapeIdGroup            RuleConfig `json:"shape_id_group"`
+	TripHeadsignGroup       RuleConfig `json:"trip_headsign_group"`
 }
 
 type StopTimesRules struct {

--- a/validator/validations/trips/main.go
+++ b/validator/validations/trips/main.go
@@ -125,5 +125,10 @@ func RunValidations(gtfs types.Gtfs, rules *types.GtfsRules) {
 		lib.AppLogger.Info(fmt.Sprintf("Completed trips.txt validation: %d rows processed", tracker.GetProcessedCount()))
 	}
 
-	validations.ValidatePatternGroups(tripsGroupedByPattern, tripsGroupedByShapeId, &gtfs)
+	var tripsRules *types.TripsRules
+	if rules != nil {
+		tripsRules = &rules.Trips
+	}
+
+	validations.ValidatePatternGroups(tripsGroupedByPattern, tripsGroupedByShapeId, &gtfs, tripsRules)
 }

--- a/validator/validations/trips/validations/direction_id_group_validation.go
+++ b/validator/validations/trips/validations/direction_id_group_validation.go
@@ -23,7 +23,7 @@ All trips with the same pattern_id must have the same direction_id.
 If a pattern_id has trips with different direction_ids, report error.
 */
 
-func DirectionIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs) {
+func DirectionIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs, rules *types.TripsRules) {
 	// Group trips by pattern_id and validate direction_id
 	for patternId, group := range tripsGroupedByPattern {
 		if len(group.Trips) == 0 {
@@ -52,6 +52,12 @@ func DirectionIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern
 		}
 		row := group.Trips[0].Row
 		ctx := lib.NewValidationContext("direction_id", "trips.txt", "direction_id_group_validation", row, services.AppMessageService)
-		ctx.AddError(ctx.GetTranslatedMessage("direction_id_group_validation.different_direction_ids_in_pattern", patternId, strings.Join(parts, ", ")))
+		if rules != nil && rules.DirectionIdGroup.Severity != "" {
+			ctx.WithSeverity(rules.DirectionIdGroup.Severity)
+		}
+		if ctx.ShouldSkip() {
+			return
+		}
+		ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("direction_id_group_validation.different_direction_ids_in_pattern", patternId, strings.Join(parts, ", ")))
 	}
 }

--- a/validator/validations/trips/validations/pattern_group_orchestrator.go
+++ b/validator/validations/trips/validations/pattern_group_orchestrator.go
@@ -14,10 +14,11 @@ func ValidatePatternGroups(
 	tripsGroupedByPattern types.TripGroupedByPattern,
 	tripsGroupedByShapeId types.TripGroupedByShapeId,
 	gtfs *types.Gtfs,
+	rules *types.TripsRules,
 ) {
-	PatternIdGroupValidation(tripsGroupedByPattern, gtfs)
-	RouteIdGroupValidation(tripsGroupedByPattern, gtfs)
-	DirectionIdGroupValidation(tripsGroupedByPattern, gtfs)
-	ShapeIdGroupValidation(tripsGroupedByPattern, tripsGroupedByShapeId, gtfs)
-	TripHeadsignGroupValidation(tripsGroupedByPattern, gtfs)
+	PatternIdGroupValidation(tripsGroupedByPattern, gtfs, rules)
+	RouteIdGroupValidation(tripsGroupedByPattern, gtfs, rules)
+	DirectionIdGroupValidation(tripsGroupedByPattern, gtfs, rules)
+	ShapeIdGroupValidation(tripsGroupedByPattern, tripsGroupedByShapeId, gtfs, rules)
+	TripHeadsignGroupValidation(tripsGroupedByPattern, gtfs, rules)
 }

--- a/validator/validations/trips/validations/pattern_id_group_validation.go
+++ b/validator/validations/trips/validations/pattern_id_group_validation.go
@@ -18,7 +18,7 @@ import (
 
 Validates if trips with the same pattern_id have the same route_id, trip_headsign, direction_id, shape_id and the same stop sequence.
 */
-func PatternIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs) {
+func PatternIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs, rules *types.TripsRules) {
 	// Group trips by pattern_id and validate the group
 	for patternId, group := range tripsGroupedByPattern {
 		if len(group.Trips) == 0 {
@@ -27,31 +27,43 @@ func PatternIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, 
 
 		for _, trip := range group.Trips {
 			ctx := lib.NewValidationContext("pattern_id", "trips.txt", "pattern_id_validation", trip.Row, services.AppMessageService)
-
+			if rules != nil && rules.PatternIdGroup.Severity != "" {
+				ctx.WithSeverity(rules.PatternIdGroup.Severity)
+			}
+			if ctx.ShouldSkip() {
+				return
+			}
 			if trip.ShapeId == nil {
-				ctx.AddError(ctx.GetTranslatedMessage("pattern_id_validation.shape_id_not_found"))
+				ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("pattern_id_validation.shape_id_not_found"))
 				continue
 			}
 
 			if trip.RouteId == nil {
-				ctx.AddError(ctx.GetTranslatedMessage("pattern_id_validation.route_id_not_found"))
+				ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("pattern_id_validation.route_id_not_found"))
 				continue
 			}
 
 			if trip.DirectionId == nil {
-				ctx.AddError(ctx.GetTranslatedMessage("pattern_id_validation.direction_id_not_found"))
+				ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("pattern_id_validation.direction_id_not_found"))
 				continue
 			}
 
 			if trip.TripHeadsign == nil {
-				ctx.AddError(ctx.GetTranslatedMessage("pattern_id_validation.trip_headsign_not_found"))
+				ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("pattern_id_validation.trip_headsign_not_found"))
 				continue
 			}
 		}
 
 		if len(group.Hash) > 1 {
-			ctx := lib.NewValidationContext("pattern_id", "trips.txt", "pattern_id_validation", group.Trips[0].Row, services.AppMessageService)
-			ctx.AddError(ctx.GetTranslatedMessage("pattern_id_validation.multiple_stop_sequence_variations", patternId))
+			row := group.Trips[0].Row
+			ctx := lib.NewValidationContext("pattern_id", "trips.txt", "pattern_id_validation", row, services.AppMessageService)
+			if rules != nil && rules.PatternIdGroup.Severity != "" {
+				ctx.WithSeverity(rules.PatternIdGroup.Severity)
+			}
+			if ctx.ShouldSkip() {
+				return
+			}
+			ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("pattern_id_validation.multiple_stop_sequence_variations", patternId))
 		}
 	}
 }

--- a/validator/validations/trips/validations/route_id_group_validation.go
+++ b/validator/validations/trips/validations/route_id_group_validation.go
@@ -22,7 +22,7 @@ All trips with the same pattern_id must have the same route_id.
 If a pattern_id has trips with different route_ids, report error.
 */
 
-func RouteIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs) {
+func RouteIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs, rules *types.TripsRules) {
 	// Group trips by pattern_id and validate route_id
 	for patternId, group := range tripsGroupedByPattern {
 		if len(group.Trips) == 0 {
@@ -47,6 +47,12 @@ func RouteIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gt
 		sort.Strings(ids)
 		row := group.Trips[0].Row
 		ctx := lib.NewValidationContext("route_id", "trips.txt", "route_id_group_validation", row, services.AppMessageService)
-		ctx.AddError(ctx.GetTranslatedMessage("route_id_group_validation.different_route_ids_in_pattern", patternId, strings.Join(ids, ", ")))
+		if rules != nil && rules.RouteIdGroup.Severity != "" {
+			ctx.WithSeverity(rules.RouteIdGroup.Severity)
+		}
+		if ctx.ShouldSkip() {
+			return
+		}
+		ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("route_id_group_validation.different_route_ids_in_pattern", patternId, strings.Join(ids, ", ")))
 	}
 }

--- a/validator/validations/trips/validations/shape_id_group_validation.go
+++ b/validator/validations/trips/validations/shape_id_group_validation.go
@@ -12,11 +12,7 @@ Processes both pattern_id groups and shape_id groups, and reports the most
 appropriate error for each inconsistency (avoids duplicate errors).
 */
 
-func ShapeIdGroupValidation(
-	tripsGroupedByPattern types.TripGroupedByPattern,
-	tripsGroupedByShapeId types.TripGroupedByShapeId,
-	gtfs *types.Gtfs,
-) {
+func ShapeIdGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, tripsGroupedByShapeId types.TripGroupedByShapeId, gtfs *types.Gtfs, rules *types.TripsRules) {
 	reportedPairs := make(map[string]bool)
 	key := func(p, s string) string { return p + "|" + s }
 
@@ -36,7 +32,13 @@ func ShapeIdGroupValidation(
 		}
 		row := group.Trips[0].Row
 		ctx := lib.NewValidationContext("pattern_id", "trips.txt", "pattern_id_validation", row, services.AppMessageService)
-		ctx.AddError(ctx.GetTranslatedMessage("pattern_id_validation.different_shape_id", patternId))
+		if rules != nil && rules.PatternIdGroup.Severity != "" {
+			ctx.WithSeverity(rules.PatternIdGroup.Severity)
+		}
+		if ctx.ShouldSkip() {
+			return
+		}
+		ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("pattern_id_validation.different_shape_id", patternId))
 		for _, trip := range group.Trips {
 			if trip.ShapeId != nil {
 				reportedPairs[key(patternId, *trip.ShapeId)] = true
@@ -70,6 +72,12 @@ func ShapeIdGroupValidation(
 		}
 		row := group.Trips[0].Row
 		ctx := lib.NewValidationContext("shape_id", "trips.txt", "shape_id_in_unique_pattern_id_validation", row, services.AppMessageService)
-		ctx.AddError(ctx.GetTranslatedMessage("shape_id_in_unique_pattern_id_validation.multiple_shape_id_in_unique_pattern_id", shapeId))
+		if rules != nil && rules.ShapeIdGroup.Severity != "" {
+			ctx.WithSeverity(rules.ShapeIdGroup.Severity)
+		}
+		if ctx.ShouldSkip() {
+			return
+		}
+		ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("shape_id_in_unique_pattern_id_validation.multiple_shape_id_in_unique_pattern_id", shapeId))
 	}
 }

--- a/validator/validations/trips/validations/trip_headsign_group_validation.go
+++ b/validator/validations/trips/validations/trip_headsign_group_validation.go
@@ -21,7 +21,8 @@ Validates that trip_headsign is unique within each pattern_id.
 All trips with the same pattern_id must have the same trip_headsign (including consistent presence: nil/empty vs non-empty).
 */
 
-func TripHeadsignGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs) {
+func TripHeadsignGroupValidation(tripsGroupedByPattern types.TripGroupedByPattern, gtfs *types.Gtfs, rules *types.TripsRules) {
+
 	for patternId, group := range tripsGroupedByPattern {
 		if len(group.Trips) == 0 {
 			panic("trips is empty")
@@ -53,9 +54,14 @@ func TripHeadsignGroupValidation(tripsGroupedByPattern types.TripGroupedByPatter
 				parts[i] = h
 			}
 		}
-
 		row := group.Trips[0].Row
 		ctx := lib.NewValidationContext("trip_headsign", "trips.txt", "trip_headsign_group_validation", row, services.AppMessageService)
-		ctx.AddError(ctx.GetTranslatedMessage("trip_headsign_group_validation.different_headsigns_in_pattern", patternId, strings.Join(parts, ", ")))
+		if rules != nil && rules.TripHeadsignGroup.Severity != "" {
+			ctx.WithSeverity(rules.TripHeadsignGroup.Severity)
+		}
+		if ctx.ShouldSkip() {
+			return
+		}
+		ctx.AddMessageWithSeverity(ctx.GetTranslatedMessage("trip_headsign_group_validation.different_headsigns_in_pattern", patternId, strings.Join(parts, ", ")))
 	}
 }


### PR DESCRIPTION
- Added validation rules for pattern_id_group, route_id_group, direction_id_group, shape_id_group, and trip_headsign_group in tml-rules.json.
- Updated TripsRules struct to include new group validation configurations.
- Modified validation functions to incorporate severity levels for new group checks, ensuring consistent error reporting.
- Enhanced existing validation logic to utilize the new rules for improved accuracy in trip data validation.